### PR TITLE
Refactor GameConfigManager to use string representations for team and quiz mode

### DIFF
--- a/Assets/Scripts/Globals/GameConfigManager.cs
+++ b/Assets/Scripts/Globals/GameConfigManager.cs
@@ -141,9 +141,9 @@ public class GameConfigManager : MonoBehaviour
     private class ConfigData
     {
         public int timeLimit;
-        public GameMode teamMode;
+        public string teamMode;
         public int numberOfPlayers;
-        public QuizMode quizMode;
+        public string quizMode;
         public int boardNumber;
     }
 
@@ -176,9 +176,9 @@ public class GameConfigManager : MonoBehaviour
     private void ApplyConfigData(ConfigData configData)
     {
         quizTimeLimit = configData.timeLimit;
-        currentMode = configData.teamMode;
+        currentMode = (GameMode)Enum.Parse(typeof(GameMode), configData.teamMode);
         numOfPlayers = configData.numberOfPlayers;
-        currentQuizMode = configData.quizMode;
+        currentQuizMode = (QuizMode)Enum.Parse(typeof(QuizMode), configData.quizMode);
         boardNumber = configData.boardNumber;
         IsFetchComplete = true;
     }


### PR DESCRIPTION
This pull request includes changes to the `Assets/Scripts/Globals/GameConfigManager.cs` file to modify how configuration data is handled. The most important changes involve converting certain fields from enums to strings and updating the parsing logic accordingly.

Changes to configuration data handling:

* [`Assets/Scripts/Globals/GameConfigManager.cs`](diffhunk://#diff-88595433011ebfb912b32ea1289684d9112ccd74ebb03598b5d97efa64d4274bL144-R146): Changed the `teamMode` and `quizMode` fields in the `ConfigData` class from `GameMode` and `QuizMode` enums to strings.
* [`Assets/Scripts/Globals/GameConfigManager.cs`](diffhunk://#diff-88595433011ebfb912b32ea1289684d9112ccd74ebb03598b5d97efa64d4274bL179-R181): Updated the `ApplyConfigData` method to parse the `teamMode` and `quizMode` fields from strings back to their respective enums using `Enum.Parse`.